### PR TITLE
223 player who was being guessed about shows name in leaderboard fixed

### DIFF
--- a/back-end/db/host.ts
+++ b/back-end/db/host.ts
@@ -137,7 +137,7 @@ export default {
     }
 
     await Game.updateOne({ id: gameId }, {
-      $set: { 'currentQuestionIndex': currentQuestionIndex + 1 }
+      $set: { 'currentQuestionIndex': nextQuestionIndex }
     });
 
     return true;

--- a/back-end/handlers/hostHelpers.ts
+++ b/back-end/handlers/hostHelpers.ts
@@ -140,19 +140,11 @@ const hostShowAnswer = async (gameId: number, io: Server): Promise<void> => {
 
 
   players.forEach(async (player) => {
-    //checks if the player id of the question (who q is abt?) is the same as this player
     if (gameData?.quizQuestions[gameData!.currentQuestionIndex].playerId == player.id) {
-      //if so will see the playerstate as the gray screen
       await playerDb.updatePlayerState(player.id, PlayerStates.SeeingAnswer, io, {});
-      //var questionPlayerGuess = guesses.find(playerGuess => playerGuess.name === gameData?.quizQuestions[gameData!.currentQuestionIndex].playerName);
-      //questionPlayerGuess?.guess = undefined
-
     } else if(player.quizGuesses[gameData!.currentQuestionIndex] == gameData?.quizQuestions[gameData!.currentQuestionIndex].correctAnswerIndex){
-      //or if their guess is correct sets to green screen
       await playerDb.updatePlayerState(player.id, PlayerStates.SeeingAnswerCorrect, io, {});
-    }
-    else {
-      //or if guess incoreect sets player state to red screen
+    } else {
       await playerDb.updatePlayerState(player.id, PlayerStates.SeeingAnswerIncorrect, io, {});
     }
   });


### PR DESCRIPTION
player guesses for each quiz question are stored in a list and accessed by the question index in the question list. when the game moves to tiebreaker, the question index becomes 0 again (like it would've been for the first question), and so was accessing the answer index for the first question and displaying that. now, when the game moves to tiebreaker, the player guesses list resets to empty.